### PR TITLE
Allow the hostname to be set

### DIFF
--- a/librato/agent.sls
+++ b/librato/agent.sls
@@ -21,7 +21,7 @@ collectd-core:
     - source: salt://librato/files/collectd.conf.jinja
     - context:
       plugin_config_path: {{ librato.plugin_config_path }}
-      {% if salt['pillar.get']('librato.hostname', False) %}
+      {% if salt['pillar.get']('librato:hostname', False) %}
       hostname: {{ librato.hostname }}
       {% endif %}
       fqdn_lookup: {{ librato.fqdn_lookup }}

--- a/librato/files/collectd.conf.jinja
+++ b/librato/files/collectd.conf.jinja
@@ -12,7 +12,7 @@
 # Global settings for the daemon.                                            #
 ##############################################################################
 
-{%- if hostname is defined -%}
+{%- if hostname is defined %}
 Hostname    "{{ hostname }}"
 {%- endif %}
 FQDNLookup   {{ fqdn_lookup }}


### PR DESCRIPTION
Fixes a bug where specifying the following would do nothing:
```
librato:
  hostname: blah
```